### PR TITLE
ReturnDestination to main menu fix

### DIFF
--- a/SubworldLibrary.cs
+++ b/SubworldLibrary.cs
@@ -2045,6 +2045,7 @@ namespace SubworldLibrary
 
 			if (index == null)
 			{
+   				cache = null;
 				Main.menuMode = 0;
 				return;
 			}


### PR DESCRIPTION
Fixed `cache.DrawMenu` still being called when exiting a subworld to the main menu (with `ReturnDestination` being `int.MinValue`)
Once the subworld had finished saving and unloading, the `cache` Subworld still had a value, so the DrawMenu method was still being drawn.

Simply setting the cache value to null once the saving was complete fixed it.
