### PR TITLE
Add Null Check for SubworldSystem.Current

### DIFF
--- a/SubworldLibrary.cs
+++ b/SubworldLibrary.cs
@@ -1001,7 +1001,7 @@ namespace SubworldLibrary
 						SubworldSystem.Exit();
 						return true;
 					case "Current":
-						return SubworldSystem.Current.FullName;
+						return SubworldSystem.Current?.FullName;
 					case "IsActive":
 						return SubworldSystem.IsActive(args[1] as string);
 					case "AnyActive":
@@ -1143,4 +1143,5 @@ namespace SubworldLibrary
 			return false;
 		}
 	}
+
 }


### PR DESCRIPTION
This change allows the "Current" Mod call to properly comply to the documented behavior. Currently, if the user is not in a subworld, SubworldSystem.Current will be null, causing attempting to access SubworldSystem.Current.FullName to throw.

This change adds the null coalescence operator, causing the returned value to be null if SubworldSystem.Current is null, complying to the documented behavior and preventing a throw if this call is used when the user is not in a subworld.